### PR TITLE
feat: extra headers during initialization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ export type ConnectionOptions = {
   readonly session?: Session;
   readonly extraCredential?: ExtraCredential;
   readonly ssl?: SecureContextOptions;
+  extraHeaders?: RequestHeaders;
 };
 
 export type QueryStage = {
@@ -192,6 +193,7 @@ class Client {
       [TRINO_EXTRA_CREDENTIAL_HEADER]: encodeAsString(
         options.extraCredential ?? {}
       ),
+      ...(options.extraHeaders ?? {}),
     };
 
     if (options.auth && options.auth.type === 'basic') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ export type ConnectionOptions = {
   readonly session?: Session;
   readonly extraCredential?: ExtraCredential;
   readonly ssl?: SecureContextOptions;
-  extraHeaders?: RequestHeaders;
+  readonly extraHeaders?: RequestHeaders;
 };
 
 export type QueryStage = {

--- a/tests/it/client.spec.ts
+++ b/tests/it/client.spec.ts
@@ -71,6 +71,22 @@ describe('trino', () => {
     expect(info.query).toBe(singleCustomerQuery);
   });
 
+  test.concurrent('client extra header propagation', async () => {
+    const source = 'new-client';
+    const trino = Trino.create({
+      catalog: 'tpcds',
+      schema: 'sf100000',
+      auth: new BasicAuth('test'),
+      extraHeaders: {'X-Trino-Source': source},
+    });
+
+    const query = await trino.query(singleCustomerQuery);
+    const qr = await query.next();
+
+    const info: any = await trino.queryInfo(qr.value.id);
+    expect(info.session.source).toBe(source);
+  });
+
   test.concurrent('query request header propagation', async () => {
     const trino = Trino.create({catalog: 'tpcds', auth: new BasicAuth('test')});
     const query = await trino.query(useSchemaQuery);


### PR DESCRIPTION
Unfortunately, this feature https://github.com/trinodb/trino-js-client/pull/568 not fully provide possibility to apply extra headers for each request to Trino. They apply only for the first one (query) and we lose them later, in next() method. If we'll add extraHeaders during client initialization, they will apply for each request.
p.s. pretty urgent, if possible