### PR TITLE
chore(deps): bump axios from 1.7.9 to 1.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typescript-eslint": "^8.14.0"
   },
   "dependencies": {
-    "axios": "1.7.9"
+    "axios": "1.8.3"
   },
   "scripts": {
     "build": "tsc --project tsconfig.build.json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1545,14 +1545,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.7.9":
-  version: 1.7.9
-  resolution: "axios@npm:1.7.9"
+"axios@npm:1.8.3":
+  version: 1.8.3
+  resolution: "axios@npm:1.8.3"
   dependencies:
     follow-redirects: ^1.15.6
     form-data: ^4.0.0
     proxy-from-env: ^1.1.0
-  checksum: cb8ce291818effda09240cb60f114d5625909b345e10f389a945320e06acf0bc949d0f8422d25720f5dd421362abee302c99f5e97edec4c156c8939814b23d19
+  checksum: 85fc8ad7d968e43ea9da5513310637d29654b181411012ee14cc0a4b3662782e6c81ac25eea40b5684f86ed2d8a01fa6fc20b9b48c4da14ef4eaee848fea43bc
   languageName: node
   linkType: hard
 
@@ -4762,7 +4762,7 @@ __metadata:
     "@types/eslint__js": ^8.42.3
     "@types/jest": ^29.5.14
     "@types/node": ^22.3.0
-    axios: 1.7.9
+    axios: 1.8.3
     eslint: 9.17.0
     eslint-plugin-jest: ^28.9.0
     jest: ^29.7.0


### PR DESCRIPTION
Closes #764 

---

## Summary

- [x] Addresses CVE-2025-27152 by bumping `axios` from `1.7.9` to `1.8.3`.