### PR TITLE
feat: add jwt auth (#524)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.7",
+  "version": "0.2.8",
   "name": "trino-client",
   "description": "Trino client library",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.8",
+  "version": "0.2.7",
   "name": "trino-client",
   "description": "Trino client library",
   "author": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,12 @@ export class BasicAuth implements Auth {
   constructor(readonly username: string, readonly password?: string) {}
 }
 
+export class JwtAuth implements Auth {
+  readonly type: AuthType = 'bearer';
+  constructor(readonly jwt: string) {}
+}
+
+
 export type Session = {[key: string]: string};
 
 export type ExtraCredential = {[key: string]: string};
@@ -170,9 +176,9 @@ const cleanHeaders = (headers: RawAxiosRequestHeaders) => {
 };
 
 /* It's a wrapper around the Axios library that adds some Trino specific headers to the requests */
-class Client {
+export class Client {
   private constructor(
-    private readonly clientConfig: AxiosRequestConfig,
+    readonly clientConfig: AxiosRequestConfig,
     private readonly options: ConnectionOptions
   ) {}
 
@@ -204,6 +210,10 @@ class Client {
       };
 
       headers[TRINO_USER_HEADER] = basic.username;
+    }
+    else if (options.auth && options.auth.type === 'bearer') {
+      const jwt: JwtAuth = <JwtAuth>options.auth;
+      headers.Authorization = `Bearer ${jwt.jwt}`;
     }
 
     clientConfig.headers = cleanHeaders(headers);

--- a/tests/it/client.spec.ts
+++ b/tests/it/client.spec.ts
@@ -1,4 +1,4 @@
-import {BasicAuth, QueryData, Trino} from '../../src';
+import {BasicAuth, JwtAuth, QueryData, Trino, Client} from '../../src';
 
 const allCustomerQuery = 'select * from customer';
 const limit = 1;
@@ -174,5 +174,24 @@ describe('trino', () => {
       ...(row.data ?? []),
     ]);
     expect(sales).toHaveLength(limit);
+  });
+
+  test.concurrent('Check JWT authentication', async () => {
+    const trino = Trino.create({
+      catalog: 'tpcds',
+      schema: 'sf100000',
+      auth: new JwtAuth('test-jwt-token'),
+    });
+    const query = await trino.query("select 1");
+  });
+
+  test.concurrent('Check Client has correct auth for JWT', async () => {
+    const client = Client.create({
+      catalog: 'tpcds',
+      schema: 'sf100000',
+      auth: new JwtAuth('test-jwt-token'),
+    });
+    const actualAuth = client.clientConfig.headers?.Authorization 
+    expect(actualAuth).toBe('Bearer test-jwt-token');
   });
 });


### PR DESCRIPTION
[Issue](https://github.com/trinodb/trino-js-client/issues/524)

Adds a simple Auth for JWT ([accessToken in Trino JDBC](https://trino.io/docs/current/security/jwt.html#using-jwts-with-clients))

Added very simple test to validate JWT is being passed correctly through the client. 

Bumped `package.json` version for release.