### PR TITLE
Allows override X-Trino-User from extraHeaders

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -203,7 +203,7 @@ class Client {
         password: basic.password ?? '',
       };
 
-      headers[TRINO_USER_HEADER] = basic.username;
+      headers[TRINO_USER_HEADER] = options.extraHeaders?.[TRINO_USER_HEADER] ?? basic.username;
     }
 
     clientConfig.headers = cleanHeaders(headers);


### PR DESCRIPTION
**Problem**
Currently, TRINO_USER_HEADER (X-Trino-User) is always set to basic.username and cannot be overridden via extraHeaders. This prevents using Trino's impersonation feature.

**Solution**
Change the priority order for setting the X-Trino-User header:

Use value from extraHeaders if provided

Fall back to basic.username

## Summary by Sourcery

Enhancements:
- Enable X-Trino-User header to be sourced from extraHeaders before defaulting to the basic.username