### PR TITLE
Adjust to trusted publishing to npm registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,50 @@
-name: Publish Package to npmjs
+name: Release and Publish
+
 on:
-  release:
-    types: [created]
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write # Required for OIDC/Trusted Publishing
+  contents: write # Required to create the GitHub release
+
 jobs:
-  build:
+  release-and-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v6
+      - name: Checkout repo
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - id: version
+        uses: EndBug/version-check@v3
+        with:
+          file-name: package.json
+          diff-search: true
+
+      - if: steps.version.outputs.changed == 'true'
+        uses: actions/setup-node@v6
         with:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
-      - name: Install Dependencies
+
+      - if: steps.version.outputs.changed == 'true'
+        name: Install dependencies
         run: yarn install --immutable
-      # Writes token to .yarnrc.yml
-      - name: Setup NPM auth token
-        run: |
-          echo npmAuthToken: "${NODE_AUTH_TOKEN}" >> ./.yarnrc.yml
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: yarn publish
+
+      - if: steps.version.outputs.changed == 'true'
+        name: Publish to npm
+        # Runs the publish script, which builds the package and then runs
+        # yarn npm publish. Authentication uses trusted publishing with OIDC,
+        # so no npm token is involved.
+        run: yarn publish
+
+      - if: steps.version.outputs.changed == 'true'
+        name: Create GitHub release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: v${{ steps.version.outputs.version }}
+          generate_release_notes: true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,5 @@
 nodeLinker: node-modules
 
+npmPublishRegistry: "https://registry.npmjs.org"
+
 yarnPath: .yarn/releases/yarn-4.18.0.cjs

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Join us on [Trino Slack](https://trino.io/slack) in
 [#core-dev](https://trinodb.slack.com/archives/C07ABNN828M) to discuss and help
 this project.
 
-[![@latest](https://img.shields.io/npm/v/trino-client.svg)](https://www.npmjs.com/package/trino-client)
+[![@latest](https://img.shields.io/npm/v/@trinodb/trino-js-client.svg)](https://www.npmjs.com/package/@trinodb/trino-js-client)
 ![it-tests](https://github.com/trinodb/trino-js-client/actions/workflows/it-tests.yml/badge.svg)
 ![license](https://img.shields.io/github/license/trinodb/trino-js-client)
 
@@ -23,7 +23,11 @@ this project.
 
 ## Install
 
-`npm install trino-client` or `yarn add trino-client`
+`npm install @trinodb/trino-js-client` or `yarn add @trinodb/trino-js-client`
+
+Versions up to and including 0.2.9 were published as `trino-client`, without a
+scope. The scoped name starts at 0.3.0. Update the dependency name to keep
+receiving new releases.
 
 ## Usage
 
@@ -178,6 +182,38 @@ Copyright
 
 ## Releasing
 
-Releases are automated with GitHub Actions and only require a pull request
-that updates the version in `package.json`. For example, see
-[PR 723](https://github.com/trinodb/trino-js-client/pull/723)
+Releases are fully automated with GitHub Actions. A release needs nothing
+beyond a merged pull request that updates the version.
+
+1. Update the `version` field in `package.json` to the version you are about to
+   release. Nothing else needs to change, since the lockfile records the
+   workspace as `0.0.0-use.local` rather than the released version.
+2. Commit the change on a branch, with `Release trino-js-client <version>` as
+   the commit message, and open a pull request.
+3. Merge the pull request once it is approved and the checks pass.
+
+Merging runs the `release` workflow, which compares the version in
+`package.json` against the preceding commit. When the version changed, the
+workflow publishes the package to npm and then creates a GitHub release, tagged
+with the version prefixed with `v`, and with generated release notes. A merge
+that leaves the version untouched publishes nothing.
+
+Watch the run to confirm that it succeeds, and check that the new version
+appears on
+[npm](https://www.npmjs.com/package/@trinodb/trino-js-client).
+
+Publishing uses
+[npm trusted publishing](https://docs.npmjs.com/trusted-publishers/) with
+OpenID Connect, so no npm token is stored in this repository. npm verifies the
+identity of the workflow directly and attaches a provenance attestation to
+every published version. The trusted publisher is configured in the package
+settings on npmjs.com and must match this repository and the `release.yml`
+workflow file name. Renaming that file breaks publishing until the
+configuration is updated to match.
+
+Publishing a package under a name that does not exist on npm yet is the one
+case this does not cover, because trusted publishing attaches its configuration
+to an existing package. The first version under a new name has to be published
+by a maintainer with access to the `@trinodb` scope, with
+`yarn npm publish --no-provenance`, since provenance is only available from a
+supported continuous integration environment.

--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
-  "version": "0.2.9",
-  "name": "trino-client",
+  "version": "0.3.1",
+  "name": "@trinodb/trino-js-client",
   "description": "Trino client library",
   "author": {
     "name": "Trino Javascript contributors",
     "email": "general@trino.io",
     "url": "https://github.com/trinodb/trino-js-client/graphs/contributors"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   },
   "keywords": [
     "trino",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1343,6 +1343,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@trinodb/trino-js-client@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "@trinodb/trino-js-client@workspace:."
+  dependencies:
+    "@eslint/js": "npm:9.25.1"
+    "@types/eslint__js": "npm:^8.42.3"
+    "@types/jest": "npm:^30.0.0"
+    "@types/node": "npm:^24.2.0"
+    axios: "npm:1.13.2"
+    eslint: "npm:9.39.1"
+    eslint-plugin-jest: "npm:^29.0.1"
+    jest: "npm:^30.0.5"
+    jiti: "npm:^2.4.0"
+    prettier: "npm:^3.0.0"
+    ts-jest: "npm:^29.2.5"
+    ts-node: "npm:^10.9.2"
+    typedoc: "npm:^0.28.3"
+    typescript: "npm:^5.6.3"
+    typescript-eslint: "npm:^8.14.0"
+  languageName: unknown
+  linkType: soft
+
 "@tsconfig/node10@npm:^1.0.7":
   version: 1.0.11
   resolution: "@tsconfig/node10@npm:1.0.11"
@@ -5271,28 +5293,6 @@ __metadata:
   checksum: 10c0/487988b0a19c654ff3e1961b87f471702e708fa8a8dd02a298ef16da7206692e8552a0250e8b3e8759270f62e9d8314616f6da274734d3b558b1fc7b7724e892
   languageName: node
   linkType: hard
-
-"trino-client@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "trino-client@workspace:."
-  dependencies:
-    "@eslint/js": "npm:9.25.1"
-    "@types/eslint__js": "npm:^8.42.3"
-    "@types/jest": "npm:^30.0.0"
-    "@types/node": "npm:^24.2.0"
-    axios: "npm:1.13.2"
-    eslint: "npm:9.39.1"
-    eslint-plugin-jest: "npm:^29.0.1"
-    jest: "npm:^30.0.5"
-    jiti: "npm:^2.4.0"
-    prettier: "npm:^3.0.0"
-    ts-jest: "npm:^29.2.5"
-    ts-node: "npm:^10.9.2"
-    typedoc: "npm:^0.28.3"
-    typescript: "npm:^5.6.3"
-    typescript-eslint: "npm:^8.14.0"
-  languageName: unknown
-  linkType: soft
 
 "ts-api-utils@npm:^2.1.0":
   version: 2.1.0


### PR DESCRIPTION
## Description

Publish the package under the `@trinodb` scope and authenticate the release workflow with [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/) instead of a stored npm token. npm verifies the workflow identity through OIDC and attaches a provenance attestation to each published version.

- Rename the package to `@trinodb/trino-js-client` and regenerate the lockfile, which records the workspace under its new name
- Bump the version to 0.3.1, which becomes the first release published by the workflow
- Grant the release job `id-token: write` for OIDC and reduce `contents` to `read`, since the workflow only publishes
- Drop the step that writes the npm token into `.yarnrc.yml`
- Request provenance through `publishConfig`
- Set `npmPublishRegistry` to the npm registry, since Yarn otherwise publishes through the `registry.yarnpkg.com` mirror
- Document the release steps and the rename in the README

## Additional context and related issues

This depends on #958, now merged. Yarn 3 cannot authenticate through OIDC at all: support arrived in [Yarn 4.10.0](https://github.com/yarnpkg/berry/pull/6898), and publishing a scoped package through it only works from [4.10.3](https://github.com/yarnpkg/berry/pull/6911) onwards. The project now runs Yarn 4.18.0.

Unlike the npm CLI, which generates provenance automatically when publishing through a trusted publisher, Yarn only does so on request. Hence `publishConfig.provenance`, which keeps this package at parity with `@trinodb/trino-query-ui`.

Yarn defaults to publishing through `https://registry.yarnpkg.com`, a mirror of the npm registry, and performs the OIDC token exchange against whichever registry it publishes to. That mirror does proxy the exchange endpoint, but the handshake should run against the registry that actually holds the trusted publisher configuration, so `npmPublishRegistry` now names the npm registry explicitly. It also matches the `registry-url` the workflow already declares.

## Automated release creation

The second commit removes the remaining manual step. Publishing a release used to require merging a version bump and then creating a GitHub release by hand, with a tag that has to match the merged version.

The workflow now triggers on pushes to `main` and detects the version change with `EndBug/version-check`, the same approach the [trino-query-ui release workflow](https://github.com/trinodb/trino-query-ui/blob/main/.github/workflows/release.yml) uses. A merge that changes the version publishes to npm and creates the matching GitHub release with generated notes. A merge that leaves the version alone publishes nothing.

One deliberate difference from trino-query-ui: this workflow publishes to npm first and creates the release afterwards. A failing publish then leaves no release and no tag behind, so the run can be repeated once the cause is fixed. In trino-query-ui, which creates the release first, a failed publish left behind a GitHub release for a version that never reached npm.

Tags keep the `v` prefix used by the existing tags, such as `v0.3.0`. The workflow file name stays `release.yml`, because the trusted publisher configuration on npmjs.com refers to it by name.

### Bootstrap already completed

`@trinodb/trino-js-client@0.3.0` is published and the trusted publisher is configured on npmjs.com for this repository and the `release.yml` workflow.

0.3.0 marks the rename and had to be published manually, because trusted publishing attaches its configuration to an existing package and therefore cannot create a package that does not exist on npm yet. That version carries no provenance attestation, since provenance is only available from a supported continuous integration environment.

Merging this pull request publishes 0.3.1, which is the first release to go out through the workflow, with a provenance attestation, no token involved, and an automatically created `v0.3.1` GitHub release.

Verified locally on Yarn 4.18.0: `yarn install --immutable`, `yarn build`, `yarn test:lint`, and `yarn pack --dry-run` all pass, and the integration tests pass against Trino 479 running in a container.
