### PR TITLE
Bump axios from 1.13.2 to 1.16.0 and update related dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typescript-eslint": "^8.14.0"
   },
   "dependencies": {
-    "axios": "1.13.2"
+    "axios": "1.16.0"
   },
   "scripts": {
     "build": "tsc --project tsconfig.build.json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2078,14 +2078,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.13.2":
-  version: 1.13.2
-  resolution: "axios@npm:1.13.2"
+"axios@npm:1.16.0":
+  version: 1.16.0
+  resolution: "axios@npm:1.16.0"
   dependencies:
-    follow-redirects: ^1.15.6
-    form-data: ^4.0.4
-    proxy-from-env: ^1.1.0
-  checksum: 057d0204d5930e2969f0bccb9f0752745b1524a36994667833195e7e1a82f245d660752ba8517b2dbea17e9e4ed0479f10b80c5fe45edd0b5a0df645c0060386
+    follow-redirects: ^1.16.0
+    form-data: ^4.0.5
+    proxy-from-env: ^2.1.0
+  checksum: 93e810968167fea59750d28f458e6860973a573c14bd60fe57ee07b5241f4c16991b149ae9ce65d79765081e3004743c9e158c438edba75af6f4612197e6834b
   languageName: node
   linkType: hard
 
@@ -3032,13 +3032,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.6":
-  version: 1.15.6
-  resolution: "follow-redirects@npm:1.15.6"
+"follow-redirects@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: a62c378dfc8c00f60b9c80cab158ba54e99ba0239a5dd7c81245e5a5b39d10f0c35e249c3379eae719ff0285fff88c365dd446fab19dee771f1d76252df1bbf5
+  checksum: e90dce4607b1f6b8b9883287f912585573c19088209ad82341d550a795b4ba514522b73b1b340cf618279df27975cd46504d09149be60291ba6767384c1fd8f8
   languageName: node
   linkType: hard
 
@@ -3052,16 +3052,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "form-data@npm:4.0.4"
+"form-data@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "form-data@npm:4.0.5"
   dependencies:
     asynckit: ^0.4.0
     combined-stream: ^1.0.8
     es-set-tostringtag: ^2.1.0
     hasown: ^2.0.2
     mime-types: ^2.1.12
-  checksum: 9b7788836df9fa5a6999e0c02515b001946b2a868cfe53f026c69e2c537a2ff9fbfb8e9d2b678744628f3dc7a2d6e14e4e45dfaf68aa6239727f0bdb8ce0abf2
+  checksum: af8328413c16d0cded5fccc975a44d227c5120fd46a9e81de8acf619d43ed838414cc6d7792195b30b248f76a65246949a129a4dadd148721948f90cd6d4fb69
   languageName: node
   linkType: hard
 
@@ -4865,10 +4865,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-from-env@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "proxy-from-env@npm:1.1.0"
-  checksum: ed7fcc2ba0a33404958e34d95d18638249a68c430e30fcb6c478497d72739ba64ce9810a24f53a7d921d0c065e5b78e3822759800698167256b04659366ca4d4
+"proxy-from-env@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "proxy-from-env@npm:2.1.0"
+  checksum: b106ad790f26d47ba4791af3fe8cba5c8d35d85020119c82c05b413eb11b3ab97d2393ecaed51bca97c2788fa256408283dfeb4d970b2ebcae6702310f064e7e
   languageName: node
   linkType: hard
 
@@ -5280,7 +5280,7 @@ __metadata:
     "@types/eslint__js": ^8.42.3
     "@types/jest": ^30.0.0
     "@types/node": ^24.2.0
-    axios: 1.13.2
+    axios: 1.16.0
     eslint: 9.39.1
     eslint-plugin-jest: ^29.0.1
     jest: ^30.0.5


### PR DESCRIPTION
## Summary                                                                                                                                                                       
   
  Updates axios from 1.13.2 to 1.16.0 to pick up multiple security fixes                                                                                                           
  released in the 1.14, 1.15, and 1.16 lines. Notable advisories addressed
  in this range:                                                                                                                                                                   
                                                                                                                                                                                   
  - GHSA-pf86-5x62-jrwf: prototype pollution via config merge (fixed 1.15.1).                                                                                                      
    `mergeConfig`, defaults resolution, and the HTTP adapter now use                                                                                                               
    own-property checks; merged configs are returned as null-prototype objects.                                                                                                    
  - Header value validation: CR/LF characters in header values now throw,
    closing the header-injection / request-smuggling vector that enabled                                                                                                           
    the IMDSv2-bypass exploit chain reported against earlier 1.x.                                                                                                                  
  - GHSA-pmwg-cvhr-8vh7 / CVE-2026-42043: incomplete fix bypass for the                                                                                                            
    NO_PROXY 127.0.0.0/8 loopback handling (fixed 1.16.0).                                                                                                                         
  - 1.16.0 hardening: configurable `maxDepth` on FormData / params                                                                                                                 
    serialization (DoS), `maxBodyLength` / `maxContentLength` now enforced                                                                                                         
    on the fetch adapter, removal of unsafe null-byte substitution in                                                                                                              
    `AxiosURLSearchParams.encode`.                                                                                                                                                 
                                                                                                                                                                                   
  Transitive lockfile bumps that came along with the resolution:                                                                                                                   
                                                                                                                                                                                   
  - follow-redirects 1.15.6 -> 1.16.0                    
  - form-data 4.0.4 -> 4.0.5                                                                                                                                                       
  - proxy-from-env 1.1.0 -> 2.1.0                                                                                                                                                  
                                                                                                                                                                                   
  ## Code impact                                                                                                                                                                   
                                                                                                                                                                                   
  None. `src/index.ts` is the only file that imports axios. Each behavior
  change in the 1.14 -> 1.16 range was reviewed against this codebase's                                                                                                            
  usage:                                                                                                                                                                           
                                                                                                                                                                                   
  - No proxy use (NO_PROXY changes do not apply).                                                                                                                                  
  - No XSRF / cookie handling.                                                                                                                                                     
  - Default Node http/https adapter, not the fetch adapter (the fetch
    adapter `maxBodyLength` change is irrelevant here).                                                                                                                            
  - Auth credentials are ASCII (`BasicAuth` username / optional password);                                                                                                         
    the new 1.16.0 URL-decoding pass is a no-op for these inputs.                                                                                                                  
  - All Trino headers are constructed as `key=value,key=value` strings                                                                                                             
    with no CR/LF, so the stricter header validation does not bite.                                                                                                                
  - Lowercase response-header access (`respHeaders[X.toLowerCase()]`) is                                                                                                           
    preserved across the range.                                                                                                                                                    
                                                                                                                                                                                   
  ## Verification                                                                                                                                                                  
                                                                                                                                                                                   
  - `yarn install` regenerates yarn.lock cleanly.        
  - `yarn test:lint` 0 errors.
  - `yarn build` clean (silent), produces `dist/index.{js,d.ts}`.                                                                                                                  
  - `yarn test:it --testTimeout=60000` runs against trinodb/trino:latest:                                                                                                          
    10/10 tests passing, including the BasicAuth path, the                                                                                                                         
    `X-Trino-Set-*` response-header round-trip in `Client.request`, and                                                                                                            
    the paginated `nextUri` follow loop in `QueryIterator`.