### PR TITLE
Remove axios in favor of native fetch + undici

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.DS_Store
+/.DS_Store
 .idea
 
 .log
@@ -19,3 +19,4 @@ docs
 .pnp.*
 
 node_modules
+/CLAUDE.md

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typescript-eslint": "^8.14.0"
   },
   "dependencies": {
-    "axios": "1.13.2"
+    "undici": "^7.0.0"
   },
   "scripts": {
     "build": "tsc --project tsconfig.build.json",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
-import axios, {AxiosRequestConfig, RawAxiosRequestHeaders} from 'axios';
-import * as https from 'https';
+import {Agent, type Dispatcher} from 'undici';
 import * as tls from 'tls';
 
 const DEFAULT_SERVER = 'http://localhost:8080';
@@ -153,14 +152,23 @@ export type Query = {
   extraHeaders?: RequestHeaders;
 };
 
+type HeaderBag = Record<string, string | undefined>;
+
+type RequestConfig = {
+  url: string;
+  method?: string;
+  headers?: HeaderBag;
+  body?: string;
+};
+
 /**
  * It takes a Headers object and returns a new object with the same keys, but only the values that are
  * truthy
- * @param {RawAxiosRequestHeaders} headers - RawAxiosRequestHeaders - The headers object to be sanitized.
+ * @param {HeaderBag} headers - The headers object to be sanitized.
  * @returns An object with the key-value pairs of the headers object, but only if the value is truthy.
  */
-const cleanHeaders = (headers: RawAxiosRequestHeaders) => {
-  const sanitizedHeaders: RawAxiosRequestHeaders = {};
+const cleanHeaders = (headers: HeaderBag): HeaderBag => {
+  const sanitizedHeaders: HeaderBag = {};
   for (const [key, value] of Object.entries(headers)) {
     if (value) {
       sanitizedHeaders[key] = value;
@@ -169,22 +177,36 @@ const cleanHeaders = (headers: RawAxiosRequestHeaders) => {
   return sanitizedHeaders;
 };
 
-/* It's a wrapper around the Axios library that adds some Trino specific headers to the requests */
+const toFetchHeaders = (headers: HeaderBag): Record<string, string> => {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (value) {
+      out[key] = value;
+    }
+  }
+  return out;
+};
+
+/* It's a wrapper around fetch that adds some Trino specific headers to the requests */
 class Client {
+  private headers: HeaderBag;
+
   private constructor(
-    private readonly clientConfig: AxiosRequestConfig,
+    private readonly baseURL: string,
+    private readonly dispatcher: Dispatcher | undefined,
+    initialHeaders: HeaderBag,
     private readonly options: ConnectionOptions
-  ) {}
+  ) {
+    this.headers = initialHeaders;
+  }
 
   static create(options: ConnectionOptions): Client {
-    const agent = new https.Agent(options.ssl ?? {});
+    const baseURL = options.server ?? DEFAULT_SERVER;
+    const dispatcher = options.ssl
+      ? new Agent({connect: options.ssl})
+      : undefined;
 
-    const clientConfig: AxiosRequestConfig = {
-      baseURL: options.server ?? DEFAULT_SERVER,
-      httpsAgent: agent,
-    };
-
-    const headers: RawAxiosRequestHeaders = {
+    const headers: HeaderBag = {
       [TRINO_USER_HEADER]: DEFAULT_USER,
       [TRINO_SOURCE_HEADER]: options.source ?? DEFAULT_SOURCE,
       [TRINO_CATALOG_HEADER]: options.catalog,
@@ -198,61 +220,76 @@ class Client {
 
     if (options.auth && options.auth.type === 'basic') {
       const basic: BasicAuth = <BasicAuth>options.auth;
-      clientConfig.auth = {
-        username: basic.username,
-        password: basic.password ?? '',
-      };
-
+      const token = Buffer.from(
+        `${basic.username}:${basic.password ?? ''}`
+      ).toString('base64');
+      headers['Authorization'] = `Basic ${token}`;
       headers[TRINO_USER_HEADER] = basic.username;
     }
 
-    clientConfig.headers = cleanHeaders(headers);
-
-    return new Client(clientConfig, options);
+    return new Client(baseURL, dispatcher, cleanHeaders(headers), options);
   }
 
   /**
    * Generic method to send a request to the server.
-   * @param cfg - AxiosRequestConfig<any>
+   * @param cfg - The request configuration.
    * @returns The response data.
    */
-  async request<T>(cfg: AxiosRequestConfig<unknown>): Promise<T> {
-    return axios
-      .create(this.clientConfig)
-      .request(cfg)
-      .then(response => {
-        const reqHeaders: RawAxiosRequestHeaders =
-          this.clientConfig.headers ?? {};
-        const respHeaders = response.headers;
-        reqHeaders[TRINO_CATALOG_HEADER] =
-          respHeaders[TRINO_SET_CATALOG_HEADER.toLowerCase()] ??
-          reqHeaders[TRINO_CATALOG_HEADER] ??
-          this.options.catalog;
-        reqHeaders[TRINO_SCHEMA_HEADER] =
-          respHeaders[TRINO_SET_SCHEMA_HEADER.toLowerCase()] ??
-          reqHeaders[TRINO_SCHEMA_HEADER] ??
-          this.options.schema;
-        reqHeaders[TRINO_SESSION_HEADER] =
-          respHeaders[TRINO_SET_SESSION_HEADER.toLowerCase()] ??
-          reqHeaders[TRINO_SESSION_HEADER] ??
-          encodeAsString(this.options.session ?? {});
+  async request<T>(cfg: RequestConfig): Promise<T> {
+    const url = new URL(cfg.url, this.baseURL).toString();
+    const mergedHeaders: HeaderBag = {
+      ...this.headers,
+      ...(cfg.headers ?? {}),
+    };
 
-        if (TRINO_CLEAR_SESSION_HEADER.toLowerCase() in respHeaders) {
-          reqHeaders[TRINO_SESSION_HEADER] = undefined;
-        }
+    const init: RequestInit & {dispatcher?: Dispatcher} = {
+      method: cfg.method ?? 'GET',
+      headers: toFetchHeaders(mergedHeaders),
+    };
+    if (cfg.body !== undefined) {
+      init.body = cfg.body;
+    }
+    if (this.dispatcher) {
+      init.dispatcher = this.dispatcher;
+    }
 
-        if (TRINO_ADDED_PREPARE_HEADER.toLowerCase() in respHeaders) {
-          const prep = reqHeaders[TRINO_PREPARED_STATEMENT_HEADER];
+    const response = await fetch(url, init);
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Trino ${response.status}: ${text}`);
+    }
 
-          reqHeaders[TRINO_PREPARED_STATEMENT_HEADER] =
-            (prep ? prep + ',' : '') +
-            respHeaders[TRINO_ADDED_PREPARE_HEADER.toLowerCase()];
-        }
+    const reqHeaders: HeaderBag = {...this.headers};
+    const respHeaders = response.headers;
 
-        this.clientConfig.headers = cleanHeaders(reqHeaders);
+    reqHeaders[TRINO_CATALOG_HEADER] =
+      respHeaders.get(TRINO_SET_CATALOG_HEADER.toLowerCase()) ??
+      reqHeaders[TRINO_CATALOG_HEADER] ??
+      this.options.catalog;
+    reqHeaders[TRINO_SCHEMA_HEADER] =
+      respHeaders.get(TRINO_SET_SCHEMA_HEADER.toLowerCase()) ??
+      reqHeaders[TRINO_SCHEMA_HEADER] ??
+      this.options.schema;
+    reqHeaders[TRINO_SESSION_HEADER] =
+      respHeaders.get(TRINO_SET_SESSION_HEADER.toLowerCase()) ??
+      reqHeaders[TRINO_SESSION_HEADER] ??
+      encodeAsString(this.options.session ?? {});
 
-        return response.data;
-      });
+    if (respHeaders.has(TRINO_CLEAR_SESSION_HEADER.toLowerCase())) {
+      reqHeaders[TRINO_SESSION_HEADER] = undefined;
+    }
+
+    if (respHeaders.has(TRINO_ADDED_PREPARE_HEADER.toLowerCase())) {
+      const prep = reqHeaders[TRINO_PREPARED_STATEMENT_HEADER];
+      reqHeaders[TRINO_PREPARED_STATEMENT_HEADER] =
+        (prep ? prep + ',' : '') +
+        respHeaders.get(TRINO_ADDED_PREPARE_HEADER.toLowerCase());
+    }
+
+    this.headers = cleanHeaders(reqHeaders);
+
+    const text = await response.text();
+    return (text ? JSON.parse(text) : undefined) as T;
   }
 
   /**
@@ -262,7 +299,7 @@ class Client {
    */
   async query(query: Query | string): Promise<Iterator<QueryResult>> {
     const req = typeof query === 'string' ? {query} : query;
-    const headers: RawAxiosRequestHeaders = {
+    const headers: HeaderBag = {
       [TRINO_USER_HEADER]: req.user,
       [TRINO_CATALOG_HEADER]: req.catalog,
       [TRINO_SCHEMA_HEADER]: req.schema,
@@ -270,12 +307,12 @@ class Client {
       [TRINO_EXTRA_CREDENTIAL_HEADER]: encodeAsString(
         req.extraCredential ?? {}
       ),
-    ...(req.extraHeaders ?? {})
+      ...(req.extraHeaders ?? {}),
     };
-    const requestConfig = {
+    const requestConfig: RequestConfig = {
       method: 'POST',
       url: '/v1/statement',
-      data: req.query,
+      body: req.query,
       headers: cleanHeaders(headers),
     };
     return this.request<QueryResult>(requestConfig).then(
@@ -389,7 +426,7 @@ export class QueryIterator implements AsyncIterableIterator<QueryResult> {
     }
 
     this.queryResult = await this.client.request<QueryResult>({
-      url: this.queryResult.nextUri,
+      url: this.queryResult.nextUri!,
     });
 
     const data = this.queryResult.data ?? [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2071,24 +2071,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asynckit@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "asynckit@npm:0.4.0"
-  checksum: 7b78c451df768adba04e2d02e63e2d0bf3b07adcd6e42b4cf665cb7ce899bedd344c69a1dcbce355b5f972d597b25aaa1c1742b52cffd9caccb22f348114f6be
-  languageName: node
-  linkType: hard
-
-"axios@npm:1.13.2":
-  version: 1.13.2
-  resolution: "axios@npm:1.13.2"
-  dependencies:
-    follow-redirects: ^1.15.6
-    form-data: ^4.0.4
-    proxy-from-env: ^1.1.0
-  checksum: 057d0204d5930e2969f0bccb9f0752745b1524a36994667833195e7e1a82f245d660752ba8517b2dbea17e9e4ed0479f10b80c5fe45edd0b5a0df645c0060386
-  languageName: node
-  linkType: hard
-
 "babel-jest@npm:30.2.0":
   version: 30.2.0
   resolution: "babel-jest@npm:30.2.0"
@@ -2273,16 +2255,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bind-apply-helpers@npm:^1.0.1, call-bind-apply-helpers@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "call-bind-apply-helpers@npm:1.0.2"
-  dependencies:
-    es-errors: ^1.3.0
-    function-bind: ^1.1.2
-  checksum: b2863d74fcf2a6948221f65d95b91b4b2d90cfe8927650b506141e669f7d5de65cea191bf788838bc40d13846b7886c5bc5c84ab96c3adbcf88ad69a72fcdc6b
-  languageName: node
-  linkType: hard
-
 "callsites@npm:^3.0.0, callsites@npm:^3.1.0":
   version: 3.1.0
   resolution: "callsites@npm:3.1.0"
@@ -2431,15 +2403,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"combined-stream@npm:^1.0.8":
-  version: 1.0.8
-  resolution: "combined-stream@npm:1.0.8"
-  dependencies:
-    delayed-stream: ~1.0.0
-  checksum: 49fa4aeb4916567e33ea81d088f6584749fc90c7abec76fd516bf1c5aa5c79f3584b5ba3de6b86d26ddd64bae5329c4c7479343250cfe71c75bb366eae53bb7c
-  languageName: node
-  linkType: hard
-
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
@@ -2521,13 +2484,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"delayed-stream@npm:~1.0.0":
-  version: 1.0.0
-  resolution: "delayed-stream@npm:1.0.0"
-  checksum: 46fe6e83e2cb1d85ba50bd52803c68be9bd953282fa7096f51fc29edd5d67ff84ff753c51966061e5ba7cb5e47ef6d36a91924eddb7f3f3483b1c560f77a0020
-  languageName: node
-  linkType: hard
-
 "detect-newline@npm:^3.1.0":
   version: 3.1.0
   resolution: "detect-newline@npm:3.1.0"
@@ -2539,17 +2495,6 @@ __metadata:
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
   checksum: f2c09b0ce4e6b301c221addd83bf3f454c0bc00caa3dd837cf6c127d6edf7223aa2bbe3b688feea110b7f262adbfc845b757c44c8a9f8c0c5b15d8fa9ce9d20d
-  languageName: node
-  linkType: hard
-
-"dunder-proto@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "dunder-proto@npm:1.0.1"
-  dependencies:
-    call-bind-apply-helpers: ^1.0.1
-    es-errors: ^1.3.0
-    gopd: ^1.2.0
-  checksum: 149207e36f07bd4941921b0ca929e3a28f1da7bd6b6ff8ff7f4e2f2e460675af4576eeba359c635723dc189b64cdd4787e0255897d5b135ccc5d15cb8685fc90
   languageName: node
   linkType: hard
 
@@ -2631,41 +2576,6 @@ __metadata:
   dependencies:
     is-arrayish: ^0.2.1
   checksum: c1c2b8b65f9c91b0f9d75f0debaa7ec5b35c266c2cac5de412c1a6de86d4cbae04ae44e510378cb14d032d0645a36925d0186f8bb7367bcc629db256b743a001
-  languageName: node
-  linkType: hard
-
-"es-define-property@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "es-define-property@npm:1.0.1"
-  checksum: 0512f4e5d564021c9e3a644437b0155af2679d10d80f21adaf868e64d30efdfbd321631956f20f42d655fedb2e3a027da479fad3fa6048f768eb453a80a5f80a
-  languageName: node
-  linkType: hard
-
-"es-errors@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "es-errors@npm:1.3.0"
-  checksum: ec1414527a0ccacd7f15f4a3bc66e215f04f595ba23ca75cdae0927af099b5ec865f9f4d33e9d7e86f512f252876ac77d4281a7871531a50678132429b1271b5
-  languageName: node
-  linkType: hard
-
-"es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "es-object-atoms@npm:1.1.1"
-  dependencies:
-    es-errors: ^1.3.0
-  checksum: 214d3767287b12f36d3d7267ef342bbbe1e89f899cfd67040309fc65032372a8e60201410a99a1645f2f90c1912c8c49c8668066f6bdd954bcd614dda2e3da97
-  languageName: node
-  linkType: hard
-
-"es-set-tostringtag@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "es-set-tostringtag@npm:2.1.0"
-  dependencies:
-    es-errors: ^1.3.0
-    get-intrinsic: ^1.2.6
-    has-tostringtag: ^1.0.2
-    hasown: ^2.0.2
-  checksum: 789f35de4be3dc8d11fdcb91bc26af4ae3e6d602caa93299a8c45cf05d36cc5081454ae2a6d3afa09cceca214b76c046e4f8151e092e6fc7feeb5efb9e794fc6
   languageName: node
   linkType: hard
 
@@ -3032,16 +2942,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.6":
-  version: 1.15.6
-  resolution: "follow-redirects@npm:1.15.6"
-  peerDependenciesMeta:
-    debug:
-      optional: true
-  checksum: a62c378dfc8c00f60b9c80cab158ba54e99ba0239a5dd7c81245e5a5b39d10f0c35e249c3379eae719ff0285fff88c365dd446fab19dee771f1d76252df1bbf5
-  languageName: node
-  linkType: hard
-
 "foreground-child@npm:^3.1.0":
   version: 3.3.0
   resolution: "foreground-child@npm:3.3.0"
@@ -3049,19 +2949,6 @@ __metadata:
     cross-spawn: ^7.0.0
     signal-exit: ^4.0.1
   checksum: 1989698488f725b05b26bc9afc8a08f08ec41807cd7b92ad85d96004ddf8243fd3e79486b8348c64a3011ae5cc2c9f0936af989e1f28339805d8bc178a75b451
-  languageName: node
-  linkType: hard
-
-"form-data@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "form-data@npm:4.0.4"
-  dependencies:
-    asynckit: ^0.4.0
-    combined-stream: ^1.0.8
-    es-set-tostringtag: ^2.1.0
-    hasown: ^2.0.2
-    mime-types: ^2.1.12
-  checksum: 9b7788836df9fa5a6999e0c02515b001946b2a868cfe53f026c69e2c537a2ff9fbfb8e9d2b678744628f3dc7a2d6e14e4e45dfaf68aa6239727f0bdb8ce0abf2
   languageName: node
   linkType: hard
 
@@ -3109,13 +2996,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"function-bind@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "function-bind@npm:1.1.2"
-  checksum: 2b0ff4ce708d99715ad14a6d1f894e2a83242e4a52ccfcefaee5e40050562e5f6dafc1adbb4ce2d4ab47279a45dc736ab91ea5042d843c3c092820dfe032efb1
-  languageName: node
-  linkType: hard
-
 "gensync@npm:^1.0.0-beta.2":
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
@@ -3130,38 +3010,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.2.6":
-  version: 1.3.0
-  resolution: "get-intrinsic@npm:1.3.0"
-  dependencies:
-    call-bind-apply-helpers: ^1.0.2
-    es-define-property: ^1.0.1
-    es-errors: ^1.3.0
-    es-object-atoms: ^1.1.1
-    function-bind: ^1.1.2
-    get-proto: ^1.0.1
-    gopd: ^1.2.0
-    has-symbols: ^1.1.0
-    hasown: ^2.0.2
-    math-intrinsics: ^1.1.0
-  checksum: 301008e4482bb9a9cb49e132b88fee093bff373b4e6def8ba219b1e96b60158a6084f273ef5cafe832e42cd93462f4accb46a618d35fe59a2b507f2388c5b79d
-  languageName: node
-  linkType: hard
-
 "get-package-type@npm:^0.1.0":
   version: 0.1.0
   resolution: "get-package-type@npm:0.1.0"
   checksum: bba0811116d11e56d702682ddef7c73ba3481f114590e705fc549f4d868972263896af313c57a25c076e3c0d567e11d919a64ba1b30c879be985fc9d44f96148
-  languageName: node
-  linkType: hard
-
-"get-proto@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "get-proto@npm:1.0.1"
-  dependencies:
-    dunder-proto: ^1.0.1
-    es-object-atoms: ^1.0.0
-  checksum: 4fc96afdb58ced9a67558698b91433e6b037aaa6f1493af77498d7c85b141382cf223c0e5946f334fb328ee85dfe6edd06d218eaf09556f4bc4ec6005d7f5f7b
   languageName: node
   linkType: hard
 
@@ -3234,13 +3086,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gopd@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "gopd@npm:1.2.0"
-  checksum: cc6d8e655e360955bdccaca51a12a474268f95bb793fc3e1f2bdadb075f28bfd1fd988dab872daf77a61d78cbaf13744bc8727a17cfb1d150d76047d805375f3
-  languageName: node
-  linkType: hard
-
 "graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
@@ -3284,31 +3129,6 @@ __metadata:
   version: 4.0.0
   resolution: "has-flag@npm:4.0.0"
   checksum: 261a1357037ead75e338156b1f9452c016a37dcd3283a972a30d9e4a87441ba372c8b81f818cd0fbcd9c0354b4ae7e18b9e1afa1971164aef6d18c2b6095a8ad
-  languageName: node
-  linkType: hard
-
-"has-symbols@npm:^1.0.3, has-symbols@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "has-symbols@npm:1.1.0"
-  checksum: b2316c7302a0e8ba3aaba215f834e96c22c86f192e7310bdf689dd0e6999510c89b00fbc5742571507cebf25764d68c988b3a0da217369a73596191ac0ce694b
-  languageName: node
-  linkType: hard
-
-"has-tostringtag@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "has-tostringtag@npm:1.0.2"
-  dependencies:
-    has-symbols: ^1.0.3
-  checksum: 999d60bb753ad714356b2c6c87b7fb74f32463b8426e159397da4bde5bca7e598ab1073f4d8d4deafac297f2eb311484cd177af242776bf05f0d11565680468d
-  languageName: node
-  linkType: hard
-
-"hasown@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "hasown@npm:2.0.2"
-  dependencies:
-    function-bind: ^1.1.2
-  checksum: e8516f776a15149ca6c6ed2ae3110c417a00b62260e222590e54aa367cbcd6ed99122020b37b7fbdf05748df57b265e70095d7bf35a47660587619b15ffb93db
   languageName: node
   linkType: hard
 
@@ -4339,13 +4159,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"math-intrinsics@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "math-intrinsics@npm:1.1.0"
-  checksum: 0e513b29d120f478c85a70f49da0b8b19bc638975eca466f2eeae0071f3ad00454c621bf66e16dd435896c208e719fc91ad79bbfba4e400fe0b372e7c1c9c9a2
-  languageName: node
-  linkType: hard
-
 "mdurl@npm:^2.0.0":
   version: 2.0.0
   resolution: "mdurl@npm:2.0.0"
@@ -4374,22 +4187,6 @@ __metadata:
     braces: ^3.0.3
     picomatch: ^2.3.1
   checksum: 79920eb634e6f400b464a954fcfa589c4e7c7143209488e44baf627f9affc8b1e306f41f4f0deedde97e69cb725920879462d3e750ab3bd3c1aed675bb3a8966
-  languageName: node
-  linkType: hard
-
-"mime-db@npm:1.52.0":
-  version: 1.52.0
-  resolution: "mime-db@npm:1.52.0"
-  checksum: 0d99a03585f8b39d68182803b12ac601d9c01abfa28ec56204fa330bc9f3d1c5e14beb049bafadb3dbdf646dfb94b87e24d4ec7b31b7279ef906a8ea9b6a513f
-  languageName: node
-  linkType: hard
-
-"mime-types@npm:^2.1.12":
-  version: 2.1.35
-  resolution: "mime-types@npm:2.1.35"
-  dependencies:
-    mime-db: 1.52.0
-  checksum: 89a5b7f1def9f3af5dad6496c5ed50191ae4331cc5389d7c521c8ad28d5fdad2d06fd81baf38fed813dc4e46bb55c8145bb0ff406330818c9cf712fb2e9b3836
   languageName: node
   linkType: hard
 
@@ -4865,13 +4662,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-from-env@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "proxy-from-env@npm:1.1.0"
-  checksum: ed7fcc2ba0a33404958e34d95d18638249a68c430e30fcb6c478497d72739ba64ce9810a24f53a7d921d0c065e5b78e3822759800698167256b04659366ca4d4
-  languageName: node
-  linkType: hard
-
 "punycode.js@npm:^2.3.1":
   version: 2.3.1
   resolution: "punycode.js@npm:2.3.1"
@@ -5280,7 +5070,6 @@ __metadata:
     "@types/eslint__js": ^8.42.3
     "@types/jest": ^30.0.0
     "@types/node": ^24.2.0
-    axios: 1.13.2
     eslint: 9.39.1
     eslint-plugin-jest: ^29.0.1
     jest: ^30.0.5
@@ -5291,6 +5080,7 @@ __metadata:
     typedoc: ^0.28.3
     typescript: ^5.6.3
     typescript-eslint: ^8.14.0
+    undici: ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -5490,6 +5280,13 @@ __metadata:
   version: 7.16.0
   resolution: "undici-types@npm:7.16.0"
   checksum: 1ef68fc6c5bad200c8b6f17de8e5bc5cfdcadc164ba8d7208cd087cfa8583d922d8316a7fd76c9a658c22b4123d3ff847429185094484fbc65377d695c905857
+  languageName: node
+  linkType: hard
+
+"undici@npm:^7.0.0":
+  version: 7.25.0
+  resolution: "undici@npm:7.25.0"
+  checksum: 502f855d69dd0f343a4b4999b995b99eab8764639983776bb5afd09b50671863244defe093e7fb97df767c948d6548c0c3d97f8dbb35fec16c1c8c1c15843f17
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
  - Drops the `axios@1.13.2` runtime dependency in favor of Node's global `fetch`
  plus `undici.Agent` (used only when `ConnectionOptions.ssl` is set, to preserve
  SSL config support).
  - Public API is unchanged. `Trino`, `Iterator`, `QueryIterator`,
  `ConnectionOptions`, `BasicAuth`, and `SecureContextOptions` all keep the same
  shape.
  - Header reconciliation against `X-Trino-Set-Catalog` / `Set-Schema` /
  `Set-Session` / `Clear-Session` / `Added-Prepare` ports 1:1.
  - Basic auth is now an explicit `Authorization: Basic <base64>` header.
  - Empty response bodies (e.g. `DELETE /v1/query/{id}`) are read via
  `response.text()` and only `JSON.parse`d when non-empty, since `Response.json()`
   throws on empty where axios tolerated it.

  ## Test plan
  - [x] `yarn build` passes
  - [x] `yarn test:lint` passes (no new warnings)
  - [x] `yarn test:it --testTimeout=60000` passes all 10 tests against a real
  Trino in kind
  - [ ] Reviewer: confirm the `ssl` SecureContextOptions wiring through
  `undici.Agent.connect` covers any in-the-wild usage you care about