### PR TITLE
Add downstream compatibility tests

### DIFF
--- a/.github/workflows/it-tests.yml
+++ b/.github/workflows/it-tests.yml
@@ -25,3 +25,8 @@ jobs:
           kubectl -n trino-system port-forward svc/trino 8080:8080 > /dev/null &
           sleep 10 # give it a little bit more time to start
           yarn test:it --testTimeout=60000
+      - name: Downstream compatibility tests
+        run: |
+          kubectl -n trino-system port-forward svc/trino 8080:8080 > /dev/null &
+          sleep 10 # give the forward time to establish
+          yarn test:compat

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ docs
 .pnp.*
 
 node_modules
+
+# compat test artifacts
+tests/compat/candidate.tgz
+tests/compat/package-lock.json

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "test:it": "jest --testPathPatterns tests/it",
+    "test:compat": "bash tests/compat/run.sh",
     "test:lint": "eslint . --flag unstable_ts_config",
     "publish": "yarn build && yarn npm publish"
   }

--- a/tests/compat/README.md
+++ b/tests/compat/README.md
@@ -1,0 +1,52 @@
+# Downstream compatibility tests
+
+These checks run against the **packed tarball**, not against `src`. They
+install the client the way a consumer installs it from npm, so they cover the
+build output, the generated declaration file, and the package manifest, none of
+which the integration tests in `tests/it` exercise.
+
+## What they cover
+
+The checks reproduce the call patterns of the largest consumers of this client
+rather than the patterns of its own tests. Lightdash drives it through a manual
+`next()` loop in `packages/warehouses`, Malloy drains it with `for await` in
+`packages/malloy-db-trino`, and Beekeeper Studio embeds it in `apps/studio`.
+Between them they depend on:
+
+* `Trino.create` with `ConnectionOptions` spread from a partial config
+* `BasicAuth`
+* `Iterator<QueryResult>`, drained both with `for await` and with `next()`
+* the observable `done` and `nextUri` sequence, including the terminal result
+  arriving twice
+* `extraHeaders` on the query object, used to send client tags
+* column metadata through `columns[].typeSignature.rawType`
+* errors read off `queryResult.error` rather than caught as a thrown exception
+* `queryInfo` and `cancel`, where the cancel issues a `DELETE` that returns an
+  empty body
+* `SET SESSION` and `RESET SESSION` replaying through the response headers
+
+The type check is as important as the run. `tsconfig.json` sets
+`skipLibCheck: false` deliberately, so `dist/index.d.ts` is checked the way a
+consumer's build checks it.
+
+## Running them locally
+
+Start a coordinator, then run the script:
+
+```shell
+docker run -d --name trino-test -p 8080:8080 trinodb/trino:latest
+until curl -s http://localhost:8080/v1/info | grep -q '"starting":false'; do
+  sleep 2
+done
+yarn test:compat
+```
+
+Point the harness at a different coordinator with `TRINO_SERVER`.
+
+## Reading a failure
+
+A check that goes from pass to fail is a break for downstream consumers.
+
+A check that still passes while its reported detail changes is a behavior
+change that needs a release note. The `done` and `nextUri` sequence is the one
+to watch, because consumers have written workarounds against its current shape.

--- a/tests/compat/package.json
+++ b/tests/compat/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "trino-js-client-compat",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Consumer-side compatibility checks for the packed client",
+  "license": "Apache-2.0",
+  "type": "commonjs",
+  "scripts": {
+    "check": "tsc --noEmit -p tsconfig.json",
+    "harness": "ts-node src/harness.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.2.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/tests/compat/run.sh
+++ b/tests/compat/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Builds the client, packs it, installs the tarball the way a consumer would,
+# and runs the compatibility harness against a Trino coordinator.
+#
+# Override the coordinator with TRINO_SERVER, which defaults to
+# http://localhost:8080.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "${here}/../.." && pwd)"
+
+echo "==> building and packing the client"
+cd "${root}"
+yarn build
+yarn pack --out "${here}/candidate.tgz"
+
+echo "==> installing the tarball as a consumer would"
+cd "${here}"
+npm install --no-audit --no-fund --loglevel=error
+npm install --no-audit --no-fund --loglevel=error --no-save ./candidate.tgz
+
+echo "==> type checking against the published declarations"
+npx tsc --noEmit -p tsconfig.json
+
+echo "==> running the harness against ${TRINO_SERVER:-http://localhost:8080}"
+npx ts-node src/harness.ts

--- a/tests/compat/src/harness.ts
+++ b/tests/compat/src/harness.ts
@@ -1,0 +1,197 @@
+/**
+ * Downstream compatibility harness for @trinodb/trino-js-client.
+ *
+ * Exercises the API surface that Lightdash, Malloy, and Beekeeper Studio
+ * actually depend on, against a local Trino coordinator on port 8080.
+ * Run it against the current release and against a candidate build, then
+ * compare the two reports.
+ */
+import {
+  Trino,
+  BasicAuth,
+  Iterator,
+  QueryResult,
+  QueryInfo,
+  ConnectionOptions,
+} from '@trinodb/trino-js-client';
+
+type Check = {name: string; ok: boolean; detail: string};
+const checks: Check[] = [];
+
+const record = (name: string, ok: boolean, detail: string) => {
+  checks.push({name, ok, detail});
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}  ${detail}`);
+};
+
+const run = async (name: string, fn: () => Promise<string>) => {
+  try {
+    record(name, true, await fn());
+  } catch (e) {
+    record(name, false, `threw ${(e as Error).name}: ${(e as Error).message}`);
+  }
+};
+
+const SERVER = process.env.TRINO_SERVER ?? 'http://localhost:8080';
+
+// The options shape Malloy builds, including the extraConfig spread that
+// forces ConnectionOptions to stay a plain structural type.
+const extraConfig: Partial<ConnectionOptions> = {source: 'harness'};
+const options: ConnectionOptions = {
+  ...extraConfig,
+  server: SERVER,
+  catalog: 'tpch',
+  schema: 'tiny',
+  auth: new BasicAuth('harness-user'),
+};
+
+const main = async () => {
+  const trino = Trino.create(options);
+
+  // Malloy: submit, drain with for-await, flatten data.
+  await run('malloy: drain query with for-await', async () => {
+    const iter: Iterator<QueryResult> = await trino.query(
+      'select name, nationkey from tpch.tiny.nation order by nationkey'
+    );
+    const rows: unknown[] = [];
+    for await (const result of iter) {
+      rows.push(...(result.data ?? []));
+    }
+    if (rows.length !== 25) throw new Error(`expected 25 rows, got ${rows.length}`);
+    return `${rows.length} rows`;
+  });
+
+  // Lightdash: manual next() loop, guarding the missing-nextUri case, and
+  // reading column type metadata off the first result.
+  await run('lightdash: next() streaming loop with nextUri guard', async () => {
+    const query = await trino.query(
+      'select custkey, name from tpch.tiny.customer order by custkey limit 500'
+    );
+    let queryResult = await query.next();
+    if (queryResult.value.error) {
+      throw new Error(`query returned error: ${JSON.stringify(queryResult.value.error)}`);
+    }
+    const schema = queryResult.value.columns ?? [];
+    if (schema.length !== 2) throw new Error(`expected 2 columns, got ${schema.length}`);
+    const raw = (schema[0] as unknown as {typeSignature?: {rawType?: string}}).typeSignature;
+    if (!raw?.rawType) throw new Error('columns[].typeSignature.rawType missing');
+
+    let streamed = (queryResult.value.data ?? []).length;
+    while (!queryResult.done) {
+      if (!queryResult.value.nextUri) {
+        queryResult = await query.next();
+        continue;
+      }
+      queryResult = await query.next();
+      streamed += (queryResult.value.data ?? []).length;
+    }
+    if (streamed !== 500) throw new Error(`expected 500 rows streamed, got ${streamed}`);
+    return `${streamed} rows, rawType=${raw.rawType}`;
+  });
+
+  // Pins the last-page semantics that Lightdash works around: the final
+  // result is delivered once with done=false and repeated with done=true.
+  await run('semantics: done and nextUri sequence across a full drain', async () => {
+    const query = await trino.query('select 1 as one');
+    const seen: Array<{done: boolean; rows: number; nextUri: boolean}> = [];
+    for (let i = 0; i < 6; i++) {
+      const r = await query.next();
+      seen.push({
+        done: !!r.done,
+        rows: (r.value.data ?? []).length,
+        nextUri: !!r.value.nextUri,
+      });
+      if (r.done) break;
+    }
+    const last = seen[seen.length - 1];
+    const prev = seen[seen.length - 2];
+    if (!last.done) throw new Error('iterator never reported done');
+    const repeats = prev !== undefined && prev.rows === last.rows && last.rows > 0;
+    return `${JSON.stringify(seen)} repeats=${repeats}`;
+  });
+
+  // Lightdash sends client tags this way; Beekeeper sends its own headers.
+  await run('extraHeaders: client tags accepted on the query object', async () => {
+    const iter = await trino.query({
+      query: 'select 1 as tagged',
+      extraHeaders: {'X-Trino-Client-Tags': 'harness=true,source=compat'},
+    });
+    let rows = 0;
+    for await (const r of iter) rows += (r.data ?? []).length;
+    if (rows !== 1) throw new Error(`expected 1 row, got ${rows}`);
+    return 'accepted';
+  });
+
+  // Lightdash reads the error off the result rather than catching a throw.
+  await run('errors: bad SQL surfaces on queryResult.value.error', async () => {
+    const query = await trino.query('select * from does_not_exist_harness');
+    let result = await query.next();
+    while (!result.value.error && !result.done) result = await query.next();
+    const err = result.value.error;
+    if (!err) throw new Error('no error field on the result');
+    if (typeof err.message !== 'string') throw new Error('error.message missing');
+    if (typeof err.errorCode !== 'number') throw new Error('error.errorCode missing');
+    return `errorName=${err.errorName} errorCode=${err.errorCode}`;
+  });
+
+  // queryInfo and cancel: cancel issues a DELETE that returns an empty body.
+  await run('queryInfo and cancel round-trip', async () => {
+    const iter = await trino.query('select count(*) from tpch.sf1.lineitem');
+    const first = await iter.next();
+    const id = first.value.id;
+    if (!id) throw new Error('no query id on the first result');
+    const info: QueryInfo = await trino.queryInfo(id);
+    if (info.queryId !== id) throw new Error(`queryInfo id mismatch: ${info.queryId} != ${id}`);
+    const cancelled = await trino.cancel(id);
+    if (cancelled.id !== id) throw new Error('cancel did not echo the query id');
+    return `id=${id} state=${info.state}`;
+  });
+
+  // Session headers have to survive the response round-trip: the client must
+  // read X-Trino-Set-Session off the response and replay it as X-Trino-Session.
+  await run('session: SET SESSION round-trips through response headers', async () => {
+    const drain = async (sql: string) => {
+      const iter = await trino.query(sql);
+      const rows: unknown[] = [];
+      for await (const r of iter) {
+        if (r.error) throw new Error(`server rejected "${sql}": ${r.error.message}`);
+        rows.push(...(r.data ?? []));
+      }
+      return rows as unknown[][];
+    };
+    const before = await drain("show session like 'query_max_run_time'");
+    await drain("set session query_max_run_time = '42m'");
+    const after = await drain("show session like 'query_max_run_time'");
+    if (after.length === 0) throw new Error('show session returned no rows');
+    const value = String(after[0][1]);
+    if (value !== '42m') {
+      throw new Error(`expected 42m after SET SESSION, got '${value}' (before: '${String(before[0]?.[1])}')`);
+    }
+    return `query_max_run_time ${String(before[0]?.[1])} -> ${value}`;
+  });
+
+  // Clearing has to work too, since RESET SESSION emits X-Trino-Clear-Session.
+  await run('session: RESET SESSION clears the replayed header', async () => {
+    const drain = async (sql: string) => {
+      const iter = await trino.query(sql);
+      const rows: unknown[] = [];
+      for await (const r of iter) rows.push(...(r.data ?? []));
+      return rows as unknown[][];
+    };
+    await drain('reset session query_max_run_time');
+    const after = await drain("show session like 'query_max_run_time'");
+    const value = String(after[0]?.[1]);
+    return `query_max_run_time reset to ${value}`;
+  });
+
+  const failed = checks.filter(c => !c.ok);
+  console.log(`\n${checks.length - failed.length}/${checks.length} checks passed`);
+  if (failed.length > 0) {
+    console.log(`failed: ${failed.map(f => f.name).join(', ')}`);
+    process.exitCode = 1;
+  }
+};
+
+main().catch(e => {
+  console.error('harness aborted:', e);
+  process.exitCode = 1;
+});

--- a/tests/compat/tsconfig.json
+++ b/tests/compat/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": false,
+    "types": ["node"],
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
The integration tests in `tests/it` exercise the client from source. They cannot catch a regression in the build output, the generated declaration file, or the package manifest, and they do not reflect how the largest consumers of this client actually call it.

This adds `tests/compat`, a consumer-side harness that installs the **packed tarball** and runs it against a Trino coordinator.

## Why now

We are heading towards 1.0.0, and #956 rewrites the transport to drop axios in favour of native fetch. That change touches request construction, response header handling, error propagation, and the empty-body `DELETE` on cancel. None of those are covered by a test that imports from `src`.

Building this harness against the current `main` already turned up two things worth knowing before that rewrite lands:

- **The terminal result is emitted twice.** `QueryIterator.next()` returns the final `queryResult` with `done: false`, then the same object again with `done: true`. Lightdash carries an explicit workaround for a variant of this, where a server returns `done: false` with no `nextUri` and the client repeats data. The harness pins the sequence so a rewrite cannot change it silently.
- **A failed query does not throw.** Querying a missing table resolves with an empty result carrying `error`. A test helper that ignores `error` reports zero rows rather than a failure, which hides exactly the bugs it is meant to catch.

## What it covers

The checks reproduce real consumer call patterns rather than this repository's own. Lightdash drives the client through a manual `next()` loop in `packages/warehouses`, Malloy drains it with `for await` in `packages/malloy-db-trino`, and Beekeeper Studio embeds it in `apps/studio`.

| Check | Surface |
|---|---|
| drain with `for await` | Malloy pattern |
| `next()` streaming loop with `nextUri` guard | Lightdash pattern, plus `columns[].typeSignature.rawType` |
| `done` and `nextUri` sequence across a drain | pins the double-emit described earlier |
| `extraHeaders` on the query object | client tags |
| errors on `queryResult.error` | not a thrown exception |
| `queryInfo` and `cancel` | the `DELETE` that returns an empty body |
| `SET SESSION` and `RESET SESSION` | response header replay |

The type check matters as much as the run. `tests/compat/tsconfig.json` sets `skipLibCheck: false` deliberately, so `dist/index.d.ts` is checked the way a consumer's build checks it, rather than trusting the source.

## CI

The harness runs as a step in the existing `it-tests` job, which already has a coordinator up. A separate job would have to start a second kind cluster for no added signal.

## Verification

```
$ yarn test:compat
==> building and packing the client
==> installing the tarball as a consumer would
==> type checking against the published declarations
==> running the harness against http://localhost:8080
PASS  malloy: drain query with for-await  25 rows
PASS  lightdash: next() streaming loop with nextUri guard  500 rows, rawType=bigint
PASS  semantics: done and nextUri sequence across a full drain  [{"done":false,"rows":1,"nextUri":true},{"done":false,"rows":0,"nextUri":false},{"done":true,"rows":0,"nextUri":false}] repeats=false
PASS  extraHeaders: client tags accepted on the query object  accepted
PASS  errors: bad SQL surfaces on queryResult.value.error  errorName=TABLE_NOT_FOUND errorCode=46
PASS  queryInfo and cancel round-trip  id=20260903_203622_00047_63xye state=FINISHING
PASS  session: SET SESSION round-trips through response headers  query_max_run_time 100.00d -> 42m
PASS  session: RESET SESSION clears the replayed header  query_max_run_time reset to 100.00d

8/8 checks passed
```

Confirmed that a failure propagates a non-zero exit code, by pointing `TRINO_SERVER` at a dead port: `0/8 checks passed`, exit code 1 through both the harness and `yarn test:compat`.

`yarn test:lint` is clean, with only the four pre-existing warnings.