### PR TITLE
Release @trinodb/trino-js-client 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.1",
+  "version": "0.3.2",
   "name": "@trinodb/trino-js-client",
   "description": "Trino client library",
   "author": {


### PR DESCRIPTION
Cuts a release from the current `main`, which is a pure dependency-maintenance release.

The motivation is downstream. Every published consumer of this client is still on `trino-client@0.2.x`, and the current published `@trinodb/trino-js-client@0.3.1` pins the same `axios@1.13.2` that `0.2.9` does. Renaming them to the scoped package today would therefore give them nothing but a new name.

`main` has since moved to axios 1.19.0, which closes the prototype pollution fix from 1.15.1, the CR/LF header injection vector, the NO_PROXY loopback bypass from 1.16.0, and raises the form-data floor past GHSA-hmw2-7cc7-3qxx. Releasing that as 0.3.2 makes the downstream rename PRs worth reviewing, because they clear real advisories rather than shuffling a name.

Malloy is the clearest case. Their dependency notes track this exact package as a standing hold:

> `high      axios, trino-client          → Trino connector maintenance`

Their lockfile carries a nested `trino-client/node_modules/axios@1.13.2` while their top level is already on 1.18.1.

## Contents since 0.3.1

- axios 1.13.2 to 1.19.0 (#967)
- typescript-eslint to 8.69.0 (#964)
- typedoc to 0.28.20 (#966)
- browserslist, `@humanfs/node`, brace-expansion, and js-yaml lockfile bumps (#969, #968, #961, #960)

No source changes, so the API is unchanged from 0.3.1.

This is a stopgap ahead of 1.0.0, which is where the axios removal in #956 and the outstanding feature PRs are headed.