### PR TITLE
Document the projects using the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,9 @@ beyond a merged pull request that updates the version.
 1. Update the `version` field in `package.json` to the version you are about to
    release. Nothing else needs to change, since the lockfile records the
    workspace as `0.0.0-use.local` rather than the released version.
-2. Commit the change on a branch, with `Release trino-js-client <version>` as
-   the commit message, and open a pull request.
+2. Commit the change on a branch, using
+   `Release @trinodb/trino-js-client <version>` as the commit message, and open
+   a pull request.
 3. Merge the pull request once it is approved and the checks pass.
 
 Merging runs the `release` workflow, which compares the version in

--- a/README.md
+++ b/README.md
@@ -74,6 +74,38 @@ const data: QueryData[] = await iter
 More usage examples can be found in the
 [integration tests](https://github.com/trinodb/trino-js-client/blob/main/tests/it/client.spec.ts).
 
+## Projects using this client
+
+The following projects use this client to talk to Trino. They are a good place
+to see it applied to a real workload, beyond the examples in this repository,
+so each entry links to the code that calls the client.
+
+- [Lightdash](https://lightdash.com) — business intelligence and analytics,
+  using the client as its Trino warehouse connector.
+  [`TrinoWarehouseClient.ts`](https://github.com/lightdash/lightdash/blob/main/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts)
+- [Malloy](https://www.malloydata.dev) — an open source language for describing
+  data relationships and transformations, in its Trino dialect connector.
+  [`packages/malloy-db-trino`](https://github.com/malloydata/malloy/tree/main/packages/malloy-db-trino)
+- [Beekeeper Studio](https://www.beekeeperstudio.io) — a cross-platform SQL
+  client and database manager.
+  [`trino.ts`](https://github.com/beekeeper-studio/beekeeper-studio/blob/master/apps/studio/src-commercial/backend/lib/db/clients/trino.ts)
+- [DBCode](https://dbcode.io) — a database editor for Visual Studio Code,
+  Cursor, and Windsurf. The extension source is not published, so only the
+  manifest is public.
+  [`dbcodeio/public`](https://github.com/dbcodeio/public)
+- [DBeagle](https://dbeagle.fyi) — a Visual Studio Code extension for SQL
+  exploration.
+  [`src/drivers/trino`](https://github.com/prasaddpathak/dbeagle/tree/master/src/drivers/trino)
+- [SQL Notebook Pro](https://github.com/kuzho/sqlnotebook-pro) — a Visual
+  Studio Code extension for SQL notebooks.
+  [`src/driver.ts`](https://github.com/kuzho/sqlnotebook-pro/blob/main/src/driver.ts)
+- [n8n-nodes-trino](https://github.com/Dmsrdnv/n8n-nodes-trino) — a community
+  node that queries Trino from an n8n workflow.
+  [`nodes/Trino`](https://github.com/Dmsrdnv/n8n-nodes-trino/tree/master/nodes/Trino)
+
+Using the client in your own project? Open a pull request and add it to the
+list.
+
 ## Build
 
 Use the following commands to build the project locally with your modifications,


### PR DESCRIPTION
Adds a "Projects using this client" section to the README, and corrects the release commit message in the same file.

## Why

We had no record of who depends on this client. That matters in two directions: users had nowhere to look for the client applied to a real workload beyond our own integration tests, and we had no way to judge the blast radius of a change to the transport or the result iteration.

That gap was concrete this week. Working out who consumes the client, so the scoped-package rename could be sent downstream, meant a GitHub code search across roughly 70 repositories from scratch. Writing the answer down means the next person does not repeat it.

## What is listed

Seven projects, each verified to depend on the package directly by reading its published manifest rather than by reputation:

| Project | Where |
|---|---|
| Lightdash | `packages/warehouses`, Trino warehouse connector |
| Malloy | `packages/malloy-db-trino`, Trino dialect connector |
| Beekeeper Studio | `apps/studio` |
| DBCode | VS Code, Cursor, and Windsurf database editor |
| DBeagle | VS Code extension |
| SQL Notebook Pro | VS Code extension |
| n8n-nodes-trino | n8n community node |

Descriptions come from each project's own repository metadata rather than my paraphrase.

Deliberately excluded: the Malloy VS Code extension, which depends on `@malloydata/db-trino` rather than on this client directly, and `regadas/sql-trino`, which is Emacs Lisp driving the CLI and has no JavaScript dependency at all. Roughly 60 further repositories reference the package but are demos, forks, or personal projects.

The section invites additions by pull request, so it can stay current without anyone having to redo the search.

## Second commit

The release instructions still said to write `Release trino-js-client <version>`, which predates the move to the scoped name at 0.3.0. Updated to `Release @trinodb/trino-js-client <version>`, matching what 0.3.2 was actually released as. Kept as a separate commit since it is an unrelated correction to the same file.

## Note for a follow-up

Not touched here, but `## Requirements` still claims Node 12 or newer. CI runs Node 24, and the removal of axios in #956 brings undici, which needs Node 20.18.1 or newer. That line wants revisiting, ideally alongside an `engines` field in `package.json`, which the manifest does not currently declare.