### PR TITLE
Declare Node 24 as the tested version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24.x"
       - name: Install Dependencies
         run: yarn install --immutable
       - name: Build

--- a/.github/workflows/it-tests.yml
+++ b/.github/workflows/it-tests.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24.x"
       - name: Install Dependencies
         run: yarn install --immutable
       - name: Create k8s Kind Cluster

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ this project.
 
 ## Requirements
 
-- Node 12 or newer.
+- Node 24 or newer. This is what the tests run against. Older and newer
+  versions may work, but are not tested.
 - Trino 0.16x or newer.
 
 ## Install


### PR DESCRIPTION
Follow-up to the note in #977. The README claimed Node 12 or newer, which predates three end-of-life releases.

## The current picture

| Line | Status | End of life |
|---|---|---|
| v20 | **already end of life** | 2026-04-30 |
| v22 | maintenance | 2027-04-30 |
| v24 | active long term support | 2028-04-30 |
| v26 | current, becomes LTS 2026-10-28 | 2029-04-30 |

Node 24 is what `main.yml` and `release.yml` already pin, so the README now states that rather than a floor nobody verifies. The wording is deliberately modest: this is what the tests run against, and older or newer versions may work but are not tested. The package targets `es2016` and uses nothing newer than `??`, which TypeScript downlevels, so it very likely runs much further back — we just do not check.

## No engines field, on purpose

I did not add `engines` to `package.json`, and I would rather we did not.

`engines` is machine-enforced, and **Yarn 1 treats a mismatch as an error rather than a warning**. Declaring `>=24` would hard-fail installs for anyone on Node 22, which is supported until 2027-04-30 and runs this code without trouble. That is not hypothetical: Beekeeper Studio, one of our consumers, is on Yarn 1, and I hit exactly this failure mode against an unrelated dependency while preparing their rename PR. Related to that [I filed an issue for them to give the project a head up](https://github.com/beekeeper-studio/beekeeper-studio/issues/4723).

The README can say "tested on 24" without the package refusing to install elsewhere. If we ever want the field, the honest value is the lowest non-EOL LTS, which would be 22 today, together with a CI matrix that actually covers it.

## Pinning two workflows

Three workflows had no `setup-node` at all and ran on whatever the `ubuntu-latest` image happened to ship, which GitHub bumps without notice:

```
main.yml     node-version: "24.x"    <- pinned
release.yml  node-version: "24.x"    <- pinned
it-tests.yml    no setup-node        <- now pinned to 24.x
docs.yml        no setup-node        <- now pinned to 24.x
codeql.yml      no setup-node        <- left alone
```

That meant the only jobs that exercise the client against a real Trino, and that build the published API documentation, were running on an unpinned version. Both are now pinned to 24.x, matching the claim in the README and the other two workflows.

CodeQL is left alone deliberately, since it supplies its own toolchain rather than running yarn.
