### PR TITLE
Document the versioning scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,17 @@ and contact us on Slack and GitHub.
 Copyright 
 [Trino JS Client contributors](https://github.com/trinodb/trino-js-client/graphs/contributors) 2022-present
 
+## Versioning
+
+From 1.0.0 onward every release increments the major version. Version 1.0.0 is
+followed by 2.0.0, then 3.0.0, with no compatibility implied between them. The
+scheme mirrors the way Trino itself numbers releases, and it sets the
+expectation that each version is its own upgrade. Read the release notes rather
+than the version number to find out what changed.
+
+Releases before 1.0.0 used ordinary semantic versioning, and versions up to and
+including 0.2.9 were published under the unscoped name `trino-client`.
+
 ## Releasing
 
 Releases are fully automated with GitHub Actions. A release needs nothing


### PR DESCRIPTION
From 1.0.0 onward every release increments the major version: 1.0.0, then 2.0.0, then 3.0.0, with no compatibility implied between them. This matches [trino-query-ui](https://github.com/trinodb/trino-query-ui) and the way Trino itself numbers releases.

Nothing in the repository said so. Without it, users reasonably assume ordinary semantic versioning and read a jump from 1.0.0 to 2.0.0 as a deliberate break rather than the normal cadence.

Worth stating **before** 1.0.0 ships rather than after, so the first release under the scheme is not also the thing that surprises people. The wording deliberately matches trino-query-ui, since a contributor reading both should not have to work out whether the difference is meaningful.

Also notes the 0.x history and the unscoped `trino-client` name, for anyone arriving from an older version.

Part of the small documentation changes going in ahead of 1.0.0, alongside #977 and #978. No code change.